### PR TITLE
Dump Lenovo Xiaoxin Pad Pro 2021 ZUI 14.0.127

### DIFF
--- a/ROM_URL.txt
+++ b/ROM_URL.txt
@@ -1,1 +1,1 @@
-https://bigota.d.miui.com/V13.0.9.0.SGMMIXM/miui-blockota-ice_global-V13.0.6.0.SGMMIXM-V13.0.9.0.SGMMIXM-27dacd3bbc-12.0.zip
+https://mobile-ota-cdn.lenovo.com/firmware/2022102110943225-9609.zip


### PR DESCRIPTION
URL: https://mobile-ota-cdn.lenovo.com/firmware/2022102110943225-9609.zip